### PR TITLE
Replace qdbus6 with qdbus

### DIFF
--- a/auto-knight
+++ b/auto-knight
@@ -20,7 +20,7 @@ set_theme() {
 
 # Gets current daylight status
 is_daylight() {
-    daylight_status=$(qdbus6 org.kde.KWin /org/kde/KWin/NightLight org.kde.KWin.NightLight.daylight)
+    daylight_status=$(qdbus org.kde.KWin /org/kde/KWin/NightLight org.kde.KWin.NightLight.daylight)
     [[ "$daylight_status" == "true" ]]
 }
 


### PR DESCRIPTION
qdbus works too and it what comes by default in Ubuntu install and derivatives. While qdbus6 is not available in all distros.